### PR TITLE
attempt to fix check_templates for issue #12

### DIFF
--- a/flask_ptrans/scripts/check_templates.py
+++ b/flask_ptrans/scripts/check_templates.py
@@ -96,7 +96,7 @@ class StringStore(object):
             json_files = glob.glob(os.path.join(directory, '*', json_filename))
         else:
             json_files = glob.glob(os.path.join(directory, json_filename))
-        for filename in json_files:
+        for filename in sorted(json_files):
             if nested:
                 dir_name = os.path.split(filename)[0]
                 owner = os.path.basename(dir_name)

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='flask-ptrans',
-    version='0.8',
+    version='0.8.1',
     description='Flask extension for localisation of templates from JSON files',
     author='Peter Harris',
     author_email='peter.harris@skyscanner.net',
     url='https://github.com/Skyscanner/flask-ptrans',
-    download_url='https://github.com/Skyscanner/flask-ptrans/tarball/0.8',
+    download_url='https://github.com/Skyscanner/flask-ptrans/tarball/0.8.1',
     packages=find_packages(),
     install_requires=['flask'],
     extras_require={'test': 'nose'},


### PR DESCRIPTION
Don't assume glob will return sorted filenames. Make results more predictable in the event of
duplicate keys occurring.