### PR TITLE
Enable fallback cascade to fallback string, fallback locale, and key

### DIFF
--- a/flask_ptrans/ptrans.py
+++ b/flask_ptrans/ptrans.py
@@ -86,6 +86,17 @@ class LazyLocalisedStringStore(object):
                 pass
         return translated
 
+    def lookup_cascade(self, locale, strid, fallback=None, fallback_locale="en-GB", **format_kwargs):
+        """
+        Localised version of a string, fallback to 1) fallback string, 2) other locale, 3) key
+        """
+        if not fallback:
+            if fallback_locale not in self.locales:
+                self.load_locale(fallback_locale)
+            fallback = self.locales[fallback_locale].get(strid, strid)
+        translated = self.lookup(locale, strid, fallback, **format_kwargs)
+        return translated
+
     def subset(self, locale, *prefixes):
         """
         Return a subset of the string store for a specified locale, where the string IDs match any of the
@@ -183,7 +194,7 @@ class PootleTranslationExtension(jinja2.ext.Extension):
         """
         jinja2.ext.Extension.__init__(self, environment)
         environment.globals.update(
-            ptrans_get=_global_string_store.lookup,
+            ptrans_get=_global_string_store.lookup_cascade,
             ptrans_subset=_global_string_store.subset)
 
     def parse(self, parser):

--- a/flask_ptrans/tests/test_lookup.py
+++ b/flask_ptrans/tests/test_lookup.py
@@ -22,10 +22,11 @@ from flask_ptrans import ptrans
 FAKE_LOCALES = {
     "en-GB": {"hello": "hello",
               "hello-who": "Hello, {who}!",
-              "other-water": "water"},
+              "other-water": "water",
+              "only-english": "only english"},
     "es-ES": {"hello": "hola",
               "hello-who": "Hola, {who}!",
-              "other-water": "agua"},
+              "other-water": "agua"}
 }
 
 
@@ -91,6 +92,48 @@ def test_lookup_substitution_wrong_type():
     """
     store = fake_string_store(FAKE_LOCALES)
     assert_equals(store.lookup(None, "hello-who", "Hello, {who}!", who="World"), "Hello, World!")
+
+
+def test_lookup_cascade_simple():
+    """
+    lookup_cascade finds correct string for locale
+    """
+    store = fake_string_store(FAKE_LOCALES)
+    assert_equals(store.lookup_cascade("en-GB", "hello"), "hello")
+    assert_equals(store.lookup_cascade("es-ES", "hello"), "hola")
+
+
+def test_lookup_cascade_fallback_string():
+    """
+    fall back to fallback string
+    """
+    store = fake_string_store(FAKE_LOCALES)
+    assert_equals(store.lookup_cascade("en-GB", "goodbye", fallback="Goodbye"), "Goodbye")
+    assert_equals(store.lookup_cascade("es-ES", "goodbye", fallback="Adios"), "Adios")
+
+
+def test_lookup_cascade_fallback_locale():
+    """
+    fall back to other locale
+    """
+    store = fake_string_store(FAKE_LOCALES)
+
+    # Fall back to en-GB by default
+    assert_equals(store.lookup_cascade(None, "hello"), "hello")
+    # Fall back to specified locale
+    assert_equals(store.lookup_cascade(None, "hello", fallback_locale="es-ES"), "hola")
+
+
+def test_lookup_cascade_no_fallback():
+    """
+    fall back to string key
+    """
+    store = fake_string_store(FAKE_LOCALES)
+    assert_equals(store.lookup_cascade("en-GB", "goodbye"), "goodbye")
+    assert_equals(store.lookup_cascade("es-ES", "goodbye"), "goodbye")
+    # If string does not exist in fallback locale, even if it does exist in en-GB,
+    # fall back to key
+    assert_equals(store.lookup_cascade("es-AR", "only-english", fallback_locale="es-ES"), "only-english")
 
 
 def test_subset():


### PR DESCRIPTION
In Facilitated Booking, we'd like to have the option not to provide a fallback string. This PR add a function that cascades through different fallbacks:

1. If the key is present in the locale, use it
2. If the key is not present, but a fallback string is provided, use that
3. If the key is not present, no fallback string is provided, use a fallback locale (default to en-GB)
4. If the key is not present in this or the fallback locale, and no fallback string is provided, return the key

This should not break the current API, but allows you to use `ptrans_get(<locale>, <key>)` without providing a fallback string. You can still provide string replacements.