### PR TITLE
Skyscanner fbp-1248: empty translations same as missing ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ The JSON files should be named using the locale of the strings they contain, in 
 `en-gb.json` or `pt-br.json`. They can be in the Pootle format as described above, or be a simple mapping from
 string ID to translated string (since you don't need to include translator comments in a deployed application).
 
+By default, empty translations are treated the same as missing translations (fall back to default string),
+but you can override this if you are really sure by specifying ``init_localisation(path, allow_empty=True)``.
+
 
 # The `ptrans_get` Function
 

--- a/flask_ptrans/tests/test_lookup.py
+++ b/flask_ptrans/tests/test_lookup.py
@@ -25,14 +25,15 @@ FAKE_LOCALES = {
               "other-water": "water",
               "only-english": "only english"},
     "es-ES": {"hello": "hola",
+              "empty": "",
               "hello-who": "Hola, {who}!",
               "other-water": "agua"},
     "fr-FR": {"hello": {"value": "bonjour", "comment": "A greeting"}}  # longer format with comment
 }
 
 
-def fake_string_store(fake_locales):
-    store = ptrans.LazyLocalisedStringStore()
+def fake_string_store(fake_locales, allow_empty=False):
+    store = ptrans.LazyLocalisedStringStore(allow_empty=allow_empty)
     store.locales = fake_locales.copy()
     return store
 
@@ -53,6 +54,17 @@ def test_lookup_no_string():
     """
     store = fake_string_store(FAKE_LOCALES)
     assert_equals(store.lookup("en-GB", "goodbye", "FAIL-EN"), "FAIL-EN")
+
+
+def test_lookup_empty_string():
+    """
+    lookup falls back to the default if translation is empty
+    unless allow_empty is True
+    """
+    store = fake_string_store(FAKE_LOCALES)
+    assert_equals(store.lookup("es-ES", "empty", "NOT EMPTY"), "NOT EMPTY")
+    store2 = fake_string_store(FAKE_LOCALES, allow_empty=True)
+    assert_equals(store2.lookup("es-ES", "empty", "NOT EMPTY"), "")
 
 
 def test_lookup_no_locale():

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='flask-ptrans',
-    version='1.1',
+    version='1.2',
     description='Flask extension for localisation of templates from JSON files',
     author='Peter Harris',
     author_email='peter.harris@skyscanner.net',
     url='https://github.com/Skyscanner/flask-ptrans',
-    download_url='https://github.com/Skyscanner/flask-ptrans/tarball/1.1',
+    download_url='https://github.com/Skyscanner/flask-ptrans/tarball/1.2',
     packages=find_packages(),
     install_requires=['flask'],
     extras_require={'test': 'nose'},


### PR DESCRIPTION
Fall back to default string if localised translation is an empty string: this means more often than not that the translation isn't available yet.